### PR TITLE
Remove onBeforeLift catch who's hiding an exception

### DIFF
--- a/src/integration/react.js
+++ b/src/integration/react.js
@@ -38,7 +38,6 @@ export class PersistGate extends PureComponent<Props, State> {
       if (this.props.onBeforeLift) {
         Promise.resolve(this.props.onBeforeLift())
           .then(() => this.setState({ bootstrapped: true }))
-          .catch(() => this.setState({ bootstrapped: true }))
       } else {
         this.setState({ bootstrapped: true })
       }


### PR DESCRIPTION
I removed the `onBeforeLift.catch`. 
If the user wants to hide the error,  from the engine he/she can still do it inside the onBeforeLift method.